### PR TITLE
Refined permissions in GitHub workflows

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -11,10 +11,12 @@ on:
     paths:
       - .github/workflows/**
 
-permissions: write-all
 jobs:
   actionlint:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
 
     steps:
       - uses: actions/checkout@v3
@@ -34,4 +36,4 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: failure() && github.repository_owner == 'nowsprinting' # Skip public fork, because can not read secrets.
+        if: failure() && github.repository_owner == 'nowsprinting' # Skip on public fork, because can not read secrets.

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -17,10 +17,12 @@ on:
     paths-ignore:
       - '**.md'
 
-permissions: write-all
 jobs:
   check-dist:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
 
     steps:
       - uses: actions/checkout@v3
@@ -63,4 +65,4 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: failure() && github.repository_owner == 'nowsprinting' # Skip public fork, because can not read secrets.
+        if: failure() && github.repository_owner == 'nowsprinting' # Skip on public fork, because can not read secrets.

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -4,10 +4,12 @@ name: Create release pull request
 on:
   workflow_dispatch:
 
-permissions: write-all
 jobs:
   create-release-pr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - name: Get draft release version

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -4,10 +4,12 @@ on:
   pull_request:
     types: [ opened ]
 
-permissions: write-all
 jobs:
   pr-labeler:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
 
     steps:
       - uses: TimonVS/pr-labeler-action@v4

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,10 +10,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: write-all
 jobs:
   release-drafter:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
 
     steps:
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,11 @@ on:
     paths:
       - package.json
 
-permissions: write-all
 jobs:
   check-bump-version:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       new-version: ${{ steps.diff.outputs.version }}
 
@@ -29,6 +30,10 @@ jobs:
     needs: check-bump-version
     if: ${{ needs.check-bump-version.outputs.new-version }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+      actions: read
 
     steps:
       - uses: release-drafter/release-drafter@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions: write-all
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v3
 
@@ -35,6 +37,9 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@v3
 
@@ -58,6 +63,8 @@ jobs:
     needs: [ build, test ]
     if: failure()
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
 
     steps:
       - uses: Gamesight/slack-workflow-status@v1.2.0


### PR DESCRIPTION
Changed the `write-all` permissions in multiple GitHub workflows to more specific permissions for different steps. This change restricts actions to necessary permissions only, enhancing security by adhering to the principle of least privilege. Each workflow now declares permissions for actions like reading content and writing/rendering pull requests. Minor comment adjustments were performed as well.
